### PR TITLE
Fix for option 'enabled' which was set to false by default

### DIFF
--- a/config.go
+++ b/config.go
@@ -31,7 +31,7 @@ type ProgramConfig struct {
 // Job attributes which are common to all job configs
 type JobMetaConfig struct {
 	Module    string `koanf:"module"`
-	Enabled   bool   `koanf:"enabled"`
+	Enabled   any    `koanf:"enabled"`
 	DryRun    bool   `koanf:"dryrun"`
 	Retention int    `koanf:"retention"`
 }
@@ -125,6 +125,7 @@ func readConfiguration(configfile string) error {
 		return fmt.Errorf("failed to unmarshal the configuration file: %v", err)
 	}
 
+	// Parse job specific sections of the config
 	jobmetadefs = make(map[string]JobMetaConfig)
 	for jobname, _ := range progconfig.Jobsdef {
 		var jobconf JobMetaConfig

--- a/main.go
+++ b/main.go
@@ -89,7 +89,8 @@ func main() {
 	// Execute all jobs defined in the configuration
 	for _, jobname := range jobnames {
 		jobconfig := jobmetadefs[jobname]
-		if jobconfig.Enabled == true {
+		jobenabled := fmt.Sprintf("%v", jobconfig.Enabled)
+		if jobenabled != "false" {
 			slog.Infof("Running job \"%s\" ...", jobname)
 			err = runJob(jobname)
 			if err != nil {

--- a/mod_ebs_snapshot.go
+++ b/mod_ebs_snapshot.go
@@ -21,7 +21,7 @@ import (
 // Structure of the job configuration for this specific module
 type JobConfigEbsSnapshot struct {
 	Module          string `koanf:"module"`
-	Enabled         bool   `koanf:"enabled"`
+	Enabled         any    `koanf:"enabled"`
 	DryRun          bool   `koanf:"dryrun"`
 	Retention       int64  `koanf:"retention"`
 	AwsRegion       string `koanf:"aws_region"`
@@ -48,7 +48,7 @@ var validateConfigJobdef = []ConfigEntryValidation{
 	},
 	{
 		entryname:  "enabled",
-		entrytype:  "bool",
+		entrytype:  "",
 		mandatory:  false,
 		defaultval: "true",
 		allowedval: []string{"true", "false"},


### PR DESCRIPTION
Have to change the type of the "enabled" option from "bool" to "any" to stop it from being set to false by default when this option is not specified explicitly.